### PR TITLE
refactor: move mock contracts to test directory

### DIFF
--- a/script/DeployMockAutomation.s.sol
+++ b/script/DeployMockAutomation.s.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.20;
 
 import "forge-std/Script.sol";
-import "../src/modules/automation/MockDistributionManager.sol";
+import "../test/mocks/MockDistributionManagerSimple.sol";
 import "../src/modules/automation/ChainlinkAutomation.sol";
 
 /// @title DeployMockAutomation
@@ -12,12 +12,12 @@ contract DeployMockAutomation is Script {
         uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
         vm.startBroadcast(deployerPrivateKey);
 
-        // Deploy MockDistributionManager
-        MockDistributionManager mockDM = new MockDistributionManager();
-        console.log("MockDistributionManager deployed at:", address(mockDM));
+        // Deploy MockDistributionManagerSimple
+        MockDistributionManagerSimple mockDM = new MockDistributionManagerSimple();
+        console.log("MockDistributionManagerSimple deployed at:", address(mockDM));
         console.log("Will trigger every 200 blocks");
 
-        // Deploy ChainlinkAutomation with MockDistributionManager
+        // Deploy ChainlinkAutomation with MockDistributionManagerSimple
         ChainlinkAutomation chainlink = new ChainlinkAutomation(address(mockDM));
         console.log("ChainlinkAutomation deployed at:", address(chainlink));
 
@@ -33,12 +33,12 @@ contract DeployMockAutomation is Script {
     }
 
     /// @notice Deploy only the mock distribution manager
-    function deployMockDistributionManager() external returns (address) {
+    function deployMockDistributionManagerSimple() external returns (address) {
         uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
         vm.startBroadcast(deployerPrivateKey);
 
-        MockDistributionManager mockDM = new MockDistributionManager();
-        console.log("MockDistributionManager deployed at:", address(mockDM));
+        MockDistributionManagerSimple mockDM = new MockDistributionManagerSimple();
+        console.log("MockDistributionManagerSimple deployed at:", address(mockDM));
 
         vm.stopBroadcast();
 

--- a/test/MockDistributionManager.t.sol
+++ b/test/MockDistributionManager.t.sol
@@ -2,15 +2,15 @@
 pragma solidity ^0.8.20;
 
 import "forge-std/Test.sol";
-import "../src/modules/automation/MockDistributionManager.sol";
+import "./mocks/MockDistributionManagerSimple.sol";
 
 contract MockDistributionManagerTest is Test {
-    MockDistributionManager public manager;
+    MockDistributionManagerSimple public manager;
 
     event MockDistributionExecuted(uint256 blockNumber);
 
     function setUp() public {
-        manager = new MockDistributionManager();
+        manager = new MockDistributionManagerSimple();
     }
 
     function test_InitialState() public view {

--- a/test/automation/AutomationBase.t.sol
+++ b/test/automation/AutomationBase.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.20;
 import "forge-std/Test.sol";
 import "../../src/modules/automation/ChainlinkAutomation.sol";
 // import "../../src/modules/automation/GelatoAutomation.sol";
-import "../../src/mocks/MockDistributionManager.sol";
+import "../mocks/MockDistributionManager.sol";
 import "../../src/interfaces/IDistributionModule.sol";
 
 contract MockDistributionModule is IDistributionModule {

--- a/test/mocks/MockDistributionManager.sol
+++ b/test/mocks/MockDistributionManager.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import "../interfaces/IDistributionManager.sol";
-import "../interfaces/IDistributionModule.sol";
+import "../../src/interfaces/IDistributionManager.sol";
+import "../../src/interfaces/IDistributionModule.sol";
 
 /// @title MockDistributionManager
 /// @notice Mock implementation of IDistributionManager for testing

--- a/test/mocks/MockDistributionManagerSimple.sol
+++ b/test/mocks/MockDistributionManagerSimple.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import "../../interfaces/IDistributionManager.sol";
+import "../../src/interfaces/IDistributionManager.sol";
 
-/// @title MockDistributionManager
+/// @title MockDistributionManagerSimple
 /// @notice Mock implementation that returns true for distribution readiness every 200 blocks
 /// @dev Simple mock for testing automation triggers
-contract MockDistributionManager is IDistributionManager {
+contract MockDistributionManagerSimple is IDistributionManager {
     uint256 public constant BLOCKS_PER_CYCLE = 200;
     uint256 public lastDistributionBlock;
 


### PR DESCRIPTION
## Summary
- Moved mock contracts from `src/` to `test/` directory where they belong
- Mock contracts should be in the test directory as they are only used for testing

## Changes
- Moved `MockDistributionManager` from `src/mocks/` to `test/mocks/`
- Moved `MockDistributionManager` from `src/modules/automation/` to `test/mocks/MockDistributionManagerSimple.sol` (renamed to avoid conflicts)
- Updated all imports in test files and deploy scripts to reference the new locations
- Removed the now-empty `src/mocks/` directory

## Test plan
- [x] All contracts compile successfully with `forge build`
- [x] No compilation errors or warnings related to the moved files

🤖 Generated with [Claude Code](https://claude.ai/code)